### PR TITLE
#50 - Restart Activity upon finish

### DIFF
--- a/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/ResultsFragment.kt
+++ b/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/ResultsFragment.kt
@@ -1,11 +1,12 @@
 package de.hsaugsburg.teamulster.sohappy.fragment
 
 import android.os.Bundle
-import android.view.*
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
-import androidx.fragment.app.Fragment
 import androidx.databinding.DataBindingUtil
-import androidx.navigation.fragment.findNavController
+import androidx.fragment.app.Fragment
 import de.hsaugsburg.teamulster.sohappy.R
 import de.hsaugsburg.teamulster.sohappy.databinding.FragmentResultsBinding
 

--- a/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/ResultsFragment.kt
+++ b/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/ResultsFragment.kt
@@ -2,6 +2,7 @@ package de.hsaugsburg.teamulster.sohappy.fragment
 
 import android.os.Bundle
 import android.view.*
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.databinding.DataBindingUtil
 import androidx.navigation.fragment.findNavController
@@ -28,9 +29,15 @@ class ResultsFragment : Fragment() {
         )
 
         binding.finishButton.setOnClickListener {
-            findNavController().navigate(R.id.homeFragment)
+            requireActivity().finish()
+            startActivity(requireActivity().intent)
         }
 
         return binding.root
+    }
+
+    override fun onStart() {
+        super.onStart()
+        (requireActivity() as AppCompatActivity).supportActionBar!!.setDisplayHomeAsUpEnabled(false)
     }
 }

--- a/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/SmileFragment.kt
+++ b/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/SmileFragment.kt
@@ -60,7 +60,7 @@ class SmileFragment : Fragment() {
         }, 8250)
 
         requireView().postDelayed({
-            findNavController().navigate(R.id.action_smileFragment_to_noSmileFragment)
+            findNavController().navigate(R.id.action_smileFragment_to_questionnaire01Fragment)
         }, 12_250)
     }
 
@@ -82,7 +82,7 @@ class SmileFragment : Fragment() {
     private fun startCountdown() {
         binding.checkmarkView.animate()
             .alpha(0f)
-            .setDuration(500)
+            .duration = 500
 
         fadeOutText()
         requireView().postDelayed({
@@ -109,20 +109,6 @@ class SmileFragment : Fragment() {
         requireView().postDelayed({
             tickCountdown()
         }, 3500)
-
-        /* requireView().postDelayed({
-            binding.countdownText.animate()
-                .alpha(0f)
-                .translationYBy(100f)
-                .setDuration(125)
-        }, 1250)
-
-        requireView().postDelayed({
-            binding.countdownText.setText("2")
-            binding.countdownText.animate()
-                .alpha(1f)
-                .setDuration(125)
-        }, 1375) */
     }
 
     private fun tickCountdown() {

--- a/app/src/main/java/de/hsaugsburg/teamulster/sohappy/view/SpinnerCustom.kt
+++ b/app/src/main/java/de/hsaugsburg/teamulster/sohappy/view/SpinnerCustom.kt
@@ -3,6 +3,11 @@ package de.hsaugsburg.teamulster.sohappy.view
 import android.content.Context
 import android.util.AttributeSet
 
+/**
+ * The default Android Spinner does not trigger an onItemSelected event if the newly selected
+ * item is the same as the previously selected one. SpinnerCustom fires onItemSelected events
+ * even if the items are the same.
+ */
 class SpinnerCustom(context: Context, attrs: AttributeSet?) :
     androidx.appcompat.widget.AppCompatSpinner(context, attrs) {
 

--- a/app/src/main/java/de/hsaugsburg/teamulster/sohappy/view/SpinnerCustom.kt
+++ b/app/src/main/java/de/hsaugsburg/teamulster/sohappy/view/SpinnerCustom.kt
@@ -1,0 +1,17 @@
+package de.hsaugsburg.teamulster.sohappy.view
+
+import android.content.Context
+import android.util.AttributeSet
+
+class SpinnerCustom(context: Context, attrs: AttributeSet?) :
+    androidx.appcompat.widget.AppCompatSpinner(context, attrs) {
+
+    override fun setSelection(position: Int) {
+        val sameSelected = position == selectedItemPosition
+        super.setSelection(position)
+
+        if (sameSelected && onItemSelectedListener != null) {
+            onItemSelectedListener!!.onItemSelected(this, selectedView, position, selectedItemId)
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_questionnaire_02.xml
+++ b/app/src/main/res/layout/fragment_questionnaire_02.xml
@@ -31,7 +31,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
 
-        <Spinner
+        <de.hsaugsburg.teamulster.sohappy.view.SpinnerCustom
             android:id="@+id/spinner"
             style="@style/SpinnerDropdownAppearanceCustom"
             android:layout_width="260dp"

--- a/app/src/main/res/layout/fragment_questionnaire_04.xml
+++ b/app/src/main/res/layout/fragment_questionnaire_04.xml
@@ -20,7 +20,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <Spinner
+        <de.hsaugsburg.teamulster.sohappy.view.SpinnerCustom
             android:id="@+id/spinner"
             style="@style/SpinnerDropdownAppearanceCustom"
             android:layout_width="260dp"

--- a/app/src/main/res/navigation/navigation.xml
+++ b/app/src/main/res/navigation/navigation.xml
@@ -148,15 +148,7 @@
         android:id="@+id/resultsFragment"
         android:name="de.hsaugsburg.teamulster.sohappy.fragment.ResultsFragment"
         android:label="@string/fragment_results_appbar_title"
-        tools:layout="@layout/fragment_results" >
-        <action
-            android:id="@+id/action_resultsFragment_to_homeFragment"
-            app:destination="@id/homeFragment"
-            app:enterAnim="@anim/enter_from_right"
-            app:exitAnim="@anim/exit_to_left"
-            app:popEnterAnim="@anim/enter_from_left"
-            app:popExitAnim="@anim/exit_to_right" />
-    </fragment>
+        tools:layout="@layout/fragment_results" />
     <fragment
         android:id="@+id/jokesFragment"
         android:name="de.hsaugsburg.teamulster.sohappy.fragment.JokesFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,7 +34,7 @@
 
     <string name="fragment_nosmile_appbar_title">No Smile Detected</string>
     <string name="fragment_nosmile_title">Something went wrong.</string>
-    <string name="fragment_nosmile_description">We couldn\'t detect a smile for at least ten seconds. You can choose to retry or continue on to the questionnaire, although your results may be slightly skewed.</string>
+    <string name="fragment_nosmile_description">We couldn\'t detect a smile for at least ten seconds. Would you like to try again or continue with the questionnaire?</string>
     <string name="fragment_nosmile_retry">Retry</string>
     <string name="fragment_nosmile_continue">Continue anyway</string>
 


### PR DESCRIPTION
Changed the Finish button in `ResultFragment` to restart the `CameraActivity` instead of navigating back to `HomeFragment`.

This pull request also contains an unrelated change: `Spinner` views do not fire `onItemSelected` events if the newly selected item is identical to the previous one. `SpinnerCustom` overrides the function responsible for firing `onItemSelected` events and ensures that events are fired even if the items are the same.