### PR TITLE
#51 - Periodic Notifications

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,8 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
+
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -42,6 +44,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.10'
+
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.4.0'
     implementation 'androidx.core:core-ktx:1.3.1'
@@ -64,6 +68,7 @@ dependencies {
 
     // local database
     implementation 'org.dizitart:potassium-nitrite:3.4.2'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.7.3'
 
     // Detection libs
     implementation 'com.quickbirdstudios:opencv:4.3.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,10 +18,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <receiver
-            android:process=":remote"
-            android:name=".notification.NotificationBroadcastReceiver" />
+        <receiver android:name=".notification.NotificationBroadcastReceiver" />
     </application>
-
 
 </manifest>

--- a/app/src/main/java/de/hsaugsburg/teamulster/sohappy/MainActivity.kt
+++ b/app/src/main/java/de/hsaugsburg/teamulster/sohappy/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.navigation.ui.NavigationUI
 import de.hsaugsburg.teamulster.sohappy.config.ConfigManager
 import de.hsaugsburg.teamulster.sohappy.database.LocalDatabaseManager
 import de.hsaugsburg.teamulster.sohappy.databinding.ActivityCameraBinding
+import de.hsaugsburg.teamulster.sohappy.notification.NotificationHandler
 import java.io.IOException
 
 /**
@@ -17,7 +18,8 @@ import java.io.IOException
  */
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityCameraBinding
-    internal lateinit var localDatabaseManager: LocalDatabaseManager
+    internal lateinit var notificationHandler: NotificationHandler
+    internal lateinit var localDatabaseManager : LocalDatabaseManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -26,16 +28,21 @@ class MainActivity : AppCompatActivity() {
         } catch (e: IOException) {
             // TODO: add proper exception handling
             ConfigManager.restoreDefaults(this)
+            ConfigManager.load(this)
         } catch (e: ClassNotFoundException) {
             // TODO: add proper exception handling
             ConfigManager.restoreDefaults(this)
+            ConfigManager.load(this)
         }
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         binding = DataBindingUtil.setContentView(this, R.layout.activity_camera)
         localDatabaseManager = LocalDatabaseManager(this)
-        val navController = findNavController(R.id.navHostFragment)
 
+        notificationHandler = NotificationHandler(this)
+        notificationHandler.createNotificationChannel()
+
+        val navController = findNavController(R.id.navHostFragment)
         NavigationUI.setupActionBarWithNavController(this, navController)
     }
 

--- a/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/ResultsFragment.kt
+++ b/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/ResultsFragment.kt
@@ -16,6 +16,7 @@ import de.hsaugsburg.teamulster.sohappy.stateMachine.Action
 import de.hsaugsburg.teamulster.sohappy.stateMachine.StateMachine
 import de.hsaugsburg.teamulster.sohappy.stateMachine.states.Start
 import de.hsaugsburg.teamulster.sohappy.viewmodel.MeasurementViewModel
+import de.hsaugsburg.teamulster.sohappy.viewmodel.SettingsViewModel
 
 /**
  * ResultsFragment serves as the conclusion of the smile procedure and provides the
@@ -25,6 +26,7 @@ class ResultsFragment : Fragment() {
     private val stateMachine: StateMachine by activityViewModels()
     private lateinit var binding: FragmentResultsBinding
     private val measurement: MeasurementViewModel by activityViewModels()
+    private val settings: SettingsViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -45,6 +47,11 @@ class ResultsFragment : Fragment() {
                 when (new) {
                     is Start -> {
                         (requireActivity() as MainActivity).localDatabaseManager.close()
+                        if (settings.notificationsEnabled) {
+                            (requireActivity() as MainActivity).notificationHandler
+                                .triggerNotificationAlarm()
+                        }
+
                         requireActivity().finish()
                         startActivity(requireActivity().intent)
                     }

--- a/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/SettingsFragment.kt
+++ b/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/SettingsFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import de.hsaugsburg.teamulster.sohappy.CameraActivity
 import de.hsaugsburg.teamulster.sohappy.R
 import de.hsaugsburg.teamulster.sohappy.databinding.FragmentSettingsBinding
 import de.hsaugsburg.teamulster.sohappy.viewmodel.SettingsViewModel
@@ -29,7 +30,19 @@ class SettingsFragment : Fragment() {
             container,
             false
         )
-        binding.viewModel = viewModel
+
+        binding.settingsNotificationSwitch.setOnCheckedChangeListener { _, new ->
+            viewModel.notificationsEnabled = new
+            val activity = requireActivity() as CameraActivity
+            if (new) {
+                activity.notificationHandler.triggerNotificationAlarm()
+            } else {
+                activity.notificationHandler.cancelNotificationAlarm()
+            }
+        }
+        binding.settingsDatabaseSwitch.setOnCheckedChangeListener { _, new ->
+            viewModel.databaseEnabled = new
+        }
 
         return binding.root
     }
@@ -37,7 +50,7 @@ class SettingsFragment : Fragment() {
     override fun onStart() {
         super.onStart()
 
-        binding.settingsNotificationSwitch.isActivated = viewModel.notificationsEnabled
-        binding.settingsDatabaseSwitch.isActivated = viewModel.databaseEnabled
+        binding.settingsNotificationSwitch.isChecked = viewModel.notificationsEnabled
+        binding.settingsDatabaseSwitch.isChecked = viewModel.databaseEnabled
     }
 }

--- a/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/SettingsFragment.kt
+++ b/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/SettingsFragment.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import de.hsaugsburg.teamulster.sohappy.CameraActivity
+import de.hsaugsburg.teamulster.sohappy.MainActivity
 import de.hsaugsburg.teamulster.sohappy.R
 import de.hsaugsburg.teamulster.sohappy.databinding.FragmentSettingsBinding
 import de.hsaugsburg.teamulster.sohappy.viewmodel.SettingsViewModel
@@ -33,7 +33,7 @@ class SettingsFragment : Fragment() {
 
         binding.settingsNotificationSwitch.setOnCheckedChangeListener { _, new ->
             viewModel.notificationsEnabled = new
-            val activity = requireActivity() as CameraActivity
+            val activity = requireActivity() as MainActivity
             if (new) {
                 activity.notificationHandler.triggerNotificationAlarm()
             } else {

--- a/app/src/main/java/de/hsaugsburg/teamulster/sohappy/notification/NotificationBroadcastReceiver.kt
+++ b/app/src/main/java/de/hsaugsburg/teamulster/sohappy/notification/NotificationBroadcastReceiver.kt
@@ -24,6 +24,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
         val notification = intent.getParcelableExtra<Notification>(
             context.getString(R.string.notification_name)
         )
+
         if (notification != null) {
             with(NotificationManagerCompat.from(context)) {
                 notify(0, notification)

--- a/app/src/main/java/de/hsaugsburg/teamulster/sohappy/notification/NotificationHandler.kt
+++ b/app/src/main/java/de/hsaugsburg/teamulster/sohappy/notification/NotificationHandler.kt
@@ -14,78 +14,95 @@ import de.hsaugsburg.teamulster.sohappy.R
  * NotificationHandler handles all actions concerning notifications, such as creating
  * Notification Channels or scheduling notifications to remind the user of something.
  */
-class NotificationHandler private constructor() {
-    companion object {
+class NotificationHandler(private val context: Context) {
+    /**
+     * Schedules an alarm telling the user to open the app every three hours.
+     *
+     * @param [context] Activity that is trying to schedule a notification.
+     * @param [delay] Delay in milliseconds specifying when the alarm should be triggered.
+     */
+    fun triggerNotificationAlarm() {
+        val notificationIntent = createNotificationIntent()
 
-        /**
-         * Schedules a notification telling the user to open the app after the provided
-         * delay.
-         *
-         * @param context Activity that is trying to schedule a notification.
-         * @param delay Delay in milliseconds specifying when the alarm should be triggered.
-         */
-        fun scheduleNotification(context: Context, delay: Long) {
-            // Create a PendingIntent that starts the app when triggered
-            val activityIntent = Intent(context, MainActivity::class.java)
-            val activityPendingIntent: PendingIntent? = TaskStackBuilder.create(context).run {
-                addNextIntentWithParentStack(activityIntent)
-                getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT)
-            }
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val delay: Long = 3 * 60 * 60 * 1000
 
-            val notification = NotificationCompat.Builder(
-                context, context.getString(R.string.channel_id)
-            ).apply {
-                setSmallIcon(R.drawable.ic_launcher_background)
-                setContentTitle("Test Title")
-                setContentText("Test Text")
-                setContentIntent(activityPendingIntent)
-                setAutoCancel(true)
-                setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            }.build()
+        alarmManager.cancel(notificationIntent)
+        alarmManager.setRepeating(
+            AlarmManager.RTC_WAKEUP,
+            SystemClock.elapsedRealtime() + delay,
+            delay,
+            notificationIntent
+        )
+    }
 
-            // Schedule the notification using a PendingIntent that is passed to the system's
-            // AlarmManager and triggered after a certain delay
-            val scheduleTime = SystemClock.elapsedRealtime() + delay
-            val scheduleIntent = Intent(context, NotificationBroadcastReceiver::class.java)
-            scheduleIntent.putExtra(context.getString(R.string.notification_name), notification)
+    /**
+     * Cancels the notification alarm for this app, regardless of whether it's actually running
+     * or not.
+     */
+    fun cancelNotificationAlarm() {
+        val notificationIntent = createNotificationIntent()
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
 
-            val schedulePendingIntent = PendingIntent.getBroadcast(
-                context,
-                0,
-                scheduleIntent,
-                PendingIntent.FLAG_CANCEL_CURRENT
-            )
+        alarmManager.cancel(notificationIntent)
+    }
 
-            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-            alarmManager.set(
-                AlarmManager.ELAPSED_REALTIME_WAKEUP,
-                scheduleTime,
-                schedulePendingIntent
-            )
+    /**
+     * Creates a notification Intent that reminds the user to open the app.
+     *
+     * @return [PendingIntent] Notification intent.
+     */
+    private fun createNotificationIntent(): PendingIntent {
+        // Create a PendingIntent that starts the app when triggered
+        val activityIntent = Intent(context, MainActivity::class.java)
+        val activityPendingIntent: PendingIntent? = TaskStackBuilder.create(context).run {
+            addNextIntentWithParentStack(activityIntent)
+            getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT)
         }
 
-        /**
-         * Starting from Android 8.0, all notifications must be associated with a Notification
-         * Channel. This function's purpose is to create a Notification Channel for this app
-         * if it does not already exist.
-         *
-         * @param context Activity that requests the creation of a new Notification Channel.
-         */
-        fun createNotificationChannel(context: Context) {
-            // Run the code only if Android version is at least 8.0
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                val name = context.resources.getString(R.string.channel_name)
-                val descriptionText = context.resources.getString(R.string.channel_description)
-                val importance = NotificationManager.IMPORTANCE_DEFAULT
-                val channel = NotificationChannel(
-                    context.resources.getString(R.string.channel_id), name, importance
-                ).apply {
-                    description = descriptionText
-                }
+        val notification = NotificationCompat.Builder(
+            context, context.getString(R.string.channel_id)
+        ).apply {
+            setSmallIcon(R.mipmap.ic_launcher)
+            setContentTitle(context.resources.getString(R.string.notification_title))
+            setContentText(context.resources.getString(R.string.notification_description))
+            setContentIntent(activityPendingIntent)
+            setAutoCancel(true)
+            priority = NotificationCompat.PRIORITY_DEFAULT
+        }.build()
 
-                with(NotificationManagerCompat.from(context)) {
-                    createNotificationChannel(channel)
-                }
+        val scheduleIntent = Intent(context, NotificationBroadcastReceiver::class.java)
+        scheduleIntent.putExtra(context.getString(R.string.notification_name), notification)
+
+        return PendingIntent.getBroadcast(
+            context,
+            0,
+            scheduleIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT
+        )
+    }
+
+    /**
+     * Starting from Android 8.0, all notifications must be associated with a Notification
+     * Channel. This function's purpose is to create a Notification Channel for this app
+     * if it does not already exist.
+     *
+     * @param [context] Activity that requests the creation of a new Notification Channel.
+     */
+    fun createNotificationChannel() {
+        // Run the code only if Android version is at least 8.0
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val name = context.resources.getString(R.string.channel_name)
+            val descriptionText = context.resources.getString(R.string.channel_description)
+            val importance = NotificationManager.IMPORTANCE_DEFAULT
+            val channel = NotificationChannel(
+                context.resources.getString(R.string.channel_id), name, importance
+            ).apply {
+                description = descriptionText
+            }
+
+            with(NotificationManagerCompat.from(context)) {
+                createNotificationChannel(channel)
             }
         }
     }

--- a/app/src/main/java/de/hsaugsburg/teamulster/sohappy/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/de/hsaugsburg/teamulster/sohappy/viewmodel/SettingsViewModel.kt
@@ -13,13 +13,13 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     var notificationsEnabled: Boolean by observable(ConfigManager.settingsConfig.notifications)
         { _, _, new ->
             ConfigManager.store(application, ConfigManager.mainConfig, SettingsConfig(
-                new, ConfigManager.settingsConfig.databaseSync)
+                new, databaseEnabled)
             )
         }
     var databaseEnabled: Boolean by observable(ConfigManager.settingsConfig.databaseSync)
         { _, _, new ->
             ConfigManager.store(application, ConfigManager.mainConfig, SettingsConfig(
-                ConfigManager.settingsConfig.notifications, new)
+                notificationsEnabled, new)
             )
         }
 

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -4,11 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".fragment.SettingsFragment">
 
-    <data>
-        <variable name="viewModel"
-            type="de.hsaugsburg.teamulster.sohappy.viewmodel.SettingsViewModel" />
-    </data>
-
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/frameLayout"
         android:layout_width="match_parent"
@@ -58,7 +53,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="24dp"
-                android:checked="@={viewModel.notificationsEnabled}"
                 android:theme="@style/SwitchAppearanceCustom"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -111,7 +105,6 @@
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="24dp"
                 android:theme="@style/SwitchAppearanceCustom"
-                android:checked="@={viewModel.databaseEnabled}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,9 @@
     <string name="channel_id">soHappy</string>
     <string name="channel_name">soHappy</string>
     <string name="channel_description">soHappy Push Notifications</string>
-    <string name="notification_name">soHappy Notification</string>
+    <string name="notification_name">soHappyNotification</string>
+    <string name="notification_title">Remember to smile!</string>
+    <string name="notification_description">It\'s been a while - tap here to open soHappy.</string>
 
     <string name="ui_start_button_name">Start</string>
     <string name="ui_welcome_title">Welcome to soHappy!</string>


### PR DESCRIPTION
Added periodic notifications if the user has enabled notifications. Their behavior is as follows:
 - Notifications trigger in three hours from tapping the Finish button in `ResultsFragment` or enabling the notification setting
 - After a notification has been triggered, another one will be started that expires three hours later
 - If the notification setting is disabled, all pending notifications will be canceled.

If you notice any errors from a botched rebase, please let me know.

EDIT: Forgot to mention that there are some changes included that I did not address in my initial comment. These are:
 - Added desugaring in order to enable Java 8+ APIs (Thanks to @craftamap 😉️)
 - Added `ConfigManager.load()` statements if an error occurs during loading and the `ConfigManager` is forced to load its default values.