### PR TITLE
#49 - Added Smile Detected Icon and Progress Bar

### DIFF
--- a/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/HomeFragment.kt
+++ b/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/HomeFragment.kt
@@ -83,7 +83,7 @@ class HomeFragment : Fragment() {
         val circleAnimation = ViewAnimationUtils.createCircularReveal(
             view,
             centerX,
-            view.height - centerY,
+            centerY,
             0f,
             radius * 1.1f
         )

--- a/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/SmileFragment.kt
+++ b/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/SmileFragment.kt
@@ -1,10 +1,13 @@
 package de.hsaugsburg.teamulster.sohappy.fragment
 
+import android.animation.ObjectAnimator
 import android.graphics.drawable.Animatable
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.AnimationUtils
+import android.view.animation.LinearInterpolator
 import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
@@ -64,6 +67,7 @@ class SmileFragment : Fragment() {
                         }
                         requireView().postDelayed(
                             {
+                                startProgressBar()
                                 stateMachine.consumeAction(Action.StimulusTimer)
                             },
                             ConfigManager.timerConfig.stimulusTimer
@@ -79,7 +83,7 @@ class SmileFragment : Fragment() {
                     )
                     is SmileCountdown -> if (old !is SmileCountdown) {
                         requireView().post {
-                            (binding.checkmarkView.drawable as Animatable).start()
+                            showSmileDetected()
                         }
                         requireView().postDelayed(
                             {
@@ -106,15 +110,6 @@ class SmileFragment : Fragment() {
 
         // The initial animation has to be started here, otherwise the animation
         // will play even if the screen is currently not focused on this fragment
-        startInitAnimation()
-    }
-
-    override fun onStop() {
-        super.onStop()
-        (requireActivity() as AppCompatActivity).supportActionBar!!.show()
-    }
-
-    private fun startInitAnimation() {
         binding.fadeInView.animate()
             .alpha(0f)
             .setDuration(1500)
@@ -124,12 +119,12 @@ class SmileFragment : Fragment() {
             }
     }
 
-    private fun startCountdown() {
-        // TODO: get sec from config
-        binding.checkmarkView.animate()
-            .alpha(0f)
-            .duration = 500
+    override fun onStop() {
+        super.onStop()
+        (requireActivity() as AppCompatActivity).supportActionBar!!.show()
+    }
 
+    private fun startCountdown() {
         fadeOutText()
         requireView().postDelayed(
             {
@@ -168,20 +163,6 @@ class SmileFragment : Fragment() {
             },
             3500
         )
-
-        /* requireView().postDelayed({
-            binding.countdownText.animate()
-                .alpha(0f)
-                .translationYBy(100f)
-                .setDuration(125)
-        }, 1250)
-
-        requireView().postDelayed({
-            binding.countdownText.setText("2")
-            binding.countdownText.animate()
-                .alpha(1f)
-                .setDuration(125)
-        }, 1375) */
     }
 
     private fun tickCountdown() {
@@ -221,5 +202,48 @@ class SmileFragment : Fragment() {
         binding.textView.animate()
             .alpha(0f)
             .duration = 500
+    }
+
+    private fun startProgressBar() {
+        binding.progressBar.apply {
+            alpha = 0f
+            progress = 0
+            visibility = View.VISIBLE
+            animate()
+                .alpha(1f)
+                .duration = 200
+        }
+        val progressAnimation =
+            ObjectAnimator.ofInt(binding.progressBar, "progress", 10_000)
+        progressAnimation.duration = 30_000
+        progressAnimation.interpolator = LinearInterpolator()
+        progressAnimation.start()
+    }
+
+    private fun showSmileDetected() {
+        binding.smileDetectedView.apply {
+            visibility = View.VISIBLE
+            startAnimation(AnimationUtils.loadAnimation(requireContext(), R.anim.scale_up_fade))
+        }
+        binding.smileDetectedViewInner.apply {
+            visibility = View.VISIBLE
+            startAnimation(
+                AnimationUtils.loadAnimation(requireContext(), R.anim.scale_up_fade_small)
+            )
+        }
+
+        requireView().postDelayed({
+            binding.smileDetectedLogoView.apply {
+                visibility = View.VISIBLE
+                startAnimation(AnimationUtils.loadAnimation(requireContext(), R.anim.scale_up_logo))
+            }
+        }, 350)
+
+        requireView().postDelayed({
+            binding.smileDetectedPulse.apply {
+                visibility = View.VISIBLE
+                startAnimation(AnimationUtils.loadAnimation(requireContext(), R.anim.pulse))
+            }
+        }, 850)
     }
 }

--- a/app/src/main/res/anim/pulse.xml
+++ b/app/src/main/res/anim/pulse.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="1000"
+    android:interpolator="@android:anim/decelerate_interpolator"
+    android:repeatMode="restart">
+
+    <scale
+        android:repeatCount="infinite"
+        android:fromXScale="0.0"
+        android:fromYScale="0.0"
+        android:pivotX="50%"
+        android:pivotY="50%"
+        android:toXScale="2"
+        android:toYScale="2" />
+
+    <alpha
+        android:repeatCount="infinite"
+        android:fromAlpha="1.0"
+        android:toAlpha="0.0" />
+
+</set>

--- a/app/src/main/res/anim/scale_up_fade.xml
+++ b/app/src/main/res/anim/scale_up_fade.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:anim/decelerate_interpolator">
+
+    <scale
+        android:duration="2000"
+        android:fromXScale="0.0"
+        android:fromYScale="0.0"
+        android:pivotX="50%"
+        android:pivotY="50%"
+        android:toXScale="3.0"
+        android:toYScale="3.0" />
+
+    <alpha android:duration="400"
+        android:fromAlpha="0.0"
+        android:toAlpha="1.0" />
+
+    <alpha
+        android:startOffset="700"
+        android:duration="300"
+        android:fromAlpha="1.0"
+        android:toAlpha="0.0" />
+
+</set>

--- a/app/src/main/res/anim/scale_up_fade_small.xml
+++ b/app/src/main/res/anim/scale_up_fade_small.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:anim/decelerate_interpolator"
+    android:startOffset="125">
+
+    <scale
+        android:duration="2000"
+        android:fromXScale="0.0"
+        android:fromYScale="0.0"
+        android:pivotX="50%"
+        android:pivotY="50%"
+        android:toXScale="2.3"
+        android:toYScale="2.3" />
+
+    <alpha android:duration="400"
+        android:fromAlpha="0.0"
+        android:toAlpha="1.0" />
+
+    <alpha
+        android:startOffset="700"
+        android:duration="300"
+        android:fromAlpha="1.0"
+        android:toAlpha="0.0" />
+
+</set>

--- a/app/src/main/res/anim/scale_up_logo.xml
+++ b/app/src/main/res/anim/scale_up_logo.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@android:integer/config_longAnimTime"
+    android:interpolator="@android:anim/decelerate_interpolator">
+
+    <scale
+        android:fromXScale="0.0"
+        android:fromYScale="0.0"
+        android:pivotX="50%"
+        android:pivotY="50%"
+        android:toXScale="1.0"
+        android:toYScale="1.0" />
+
+    <alpha android:fromAlpha="0.0"
+        android:toAlpha="1.0" />
+
+</set>

--- a/app/src/main/res/drawable/ic_pulse.xml
+++ b/app/src/main/res/drawable/ic_pulse.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/colorPrimary"/>
+</shape>

--- a/app/src/main/res/drawable/ic_smile_detected.xml
+++ b/app/src/main/res/drawable/ic_smile_detected.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <group>
+        <path
+            android:name="smile_detected_circle"
+            android:strokeColor="@android:color/white"
+            android:strokeWidth="0.7"
+            android:pathData="M12,12m-10,0a10,10 0,1 1,20 0a10,10 0,1 1,-20 0" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/progress_background.xml
+++ b/app/src/main/res/drawable/progress_background.xml
@@ -1,0 +1,18 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@android:id/background">
+        <shape>
+            <corners android:radius="5dp" />
+            <solid android:color="@android:color/white" />
+        </shape>
+    </item>
+
+    <item android:id="@android:id/progress">
+        <clip>
+            <shape>
+                <corners
+                    android:radius="5dp" />
+                <solid android:color="@color/colorPrimary" />
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/fragment_smile.xml
+++ b/app/src/main/res/layout/fragment_smile.xml
@@ -39,16 +39,20 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <ImageView
-            android:id="@+id/checkmarkView"
-            android:layout_width="75dp"
-            android:layout_height="75dp"
-            android:layout_marginBottom="48dp"
-            android:contentDescription="@string/fragment_camera_checkmark_text"
-            app:layout_constraintBottom_toBottomOf="parent"
+        <ProgressBar
+            android:id="@+id/progressBar"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="220dp"
+            android:layout_height="4dp"
+            android:layout_marginTop="32dp"
+            android:indeterminate="false"
+            android:max="10000"
+            android:progress="0"
+            android:progressDrawable="@drawable/progress_background"
+            android:visibility="invisible"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:srcCompat="@drawable/animated_checkmark" />
+            app:layout_constraintTop_toBottomOf="@+id/textView" />
 
         <TextView
             android:id="@+id/countdownText"
@@ -67,12 +71,56 @@
             android:id="@+id/countdownView"
             android:layout_width="100dp"
             android:layout_height="100dp"
-            android:contentDescription="@string/fragment_camera_countdown_text"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:srcCompat="@drawable/animated_countdown" />
+
+        <ImageView
+            android:id="@+id/smileDetectedView"
+            android:layout_width="75dp"
+            android:layout_height="75dp"
+            android:layout_marginBottom="48dp"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:srcCompat="@drawable/ic_smile_detected" />
+
+        <ImageView
+            android:id="@+id/smileDetectedViewInner"
+            android:layout_width="75dp"
+            android:layout_height="75dp"
+            android:layout_marginBottom="48dp"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:srcCompat="@drawable/ic_smile_detected" />
+
+        <ImageView
+            android:id="@+id/smileDetectedLogoView"
+            android:layout_width="75dp"
+            android:layout_height="75dp"
+            android:layout_marginBottom="48dp"
+            android:visibility="invisible"
+            android:translationZ="1dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:srcCompat="@mipmap/ic_launcher_round" />
+
+        <ImageView
+            android:id="@+id/smileDetectedPulse"
+            android:layout_width="75dp"
+            android:layout_height="75dp"
+            android:layout_marginBottom="48dp"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:srcCompat="@drawable/ic_pulse" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
Users now receive more visual feedback with the following two views:
 - ProgressBar: Slowls fills up over 30 seconds after the stimulus is shown
 - SmileDetectedLogo: Displayed once a smile has been detected

Unrelated changes:
 - The circular reveal animation in `HomeFragment` is now positioned at the bottom.