### PR TITLE
Moving progressbar up

### DIFF
--- a/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/SmileFragment.kt
+++ b/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/SmileFragment.kt
@@ -73,7 +73,6 @@ class SmileFragment : Fragment() {
                         }
                         requireView().postDelayed(
                             {
-                                startProgressBar()
                                 stateMachine.consumeAction(Action.StimulusTimer)
                             },
                             ConfigManager.timerConfig.stimulusTimer
@@ -90,6 +89,7 @@ class SmileFragment : Fragment() {
                     is SmileCountdown -> if (old !is SmileCountdown) {
                         requireView().post {
                             showSmileDetected()
+                            startProgressBar()
                         }
                         requireView().postDelayed(
                             {
@@ -221,7 +221,7 @@ class SmileFragment : Fragment() {
         }
         val progressAnimation =
             ObjectAnimator.ofInt(binding.progressBar, "progress", 10_000)
-        progressAnimation.duration = 30_000
+        progressAnimation.duration = ConfigManager.timerConfig.smileTimer
         progressAnimation.interpolator = LinearInterpolator()
         progressAnimation.start()
     }

--- a/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/SmileFragment.kt
+++ b/app/src/main/java/de/hsaugsburg/teamulster/sohappy/fragment/SmileFragment.kt
@@ -58,7 +58,7 @@ class SmileFragment : Fragment() {
             if (this.isResumed) {
                 when (new) {
                     is Start -> {
-                        (requireActivity() as MainActivity).localDatabaseManager.close()
+                        (requireActivity() as MainActivity).localDatabaseManager?.close()
                         requireActivity().finish()
                         startActivity(requireActivity().intent)
                     }

--- a/app/src/main/res/layout/fragment_smile.xml
+++ b/app/src/main/res/layout/fragment_smile.xml
@@ -42,9 +42,8 @@
         <ProgressBar
             android:id="@+id/progressBar"
             style="?android:attr/progressBarStyleHorizontal"
-            android:layout_width="220dp"
+            android:layout_width="match_parent"
             android:layout_height="4dp"
-            android:layout_marginTop="32dp"
             android:indeterminate="false"
             android:max="10000"
             android:progress="0"
@@ -52,7 +51,7 @@
             android:visibility="invisible"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textView" />
+            app:layout_constraintTop_toTopOf="@+id/gpuImageView" />
 
         <TextView
             android:id="@+id/countdownText"


### PR DESCRIPTION
We talked about moving the progress bar for the SmileDetected state, on the screen-edge (much like instagram and whatsapp). This looks like this:

![Screenshot_20200920-112445](https://user-images.githubusercontent.com/6420231/93708239-df36c080-fb34-11ea-88e5-804b105f3c2a.png)

It also fixes that the animation was started an state to early.
